### PR TITLE
Say "not (directly) live" rather than "never live"

### DIFF
--- a/0000-nonlexical-lifetimes.md
+++ b/0000-nonlexical-lifetimes.md
@@ -719,8 +719,14 @@ type of `p`. (Later on, when we cover the dropck, we will use a more
 selection notion of liveness for lifetimes in which *some* of the
 lifetimes in a variable's type may be live while others are not.) So,
 in our running example, the lifetime `'p` would be live at precisely
-the same points that `p` is live. The lifetimes `'foo` and `'bar` are
-never live, since they do not appear in the types of any variables.
+the same points that `p` is live. The lifetimes `'foo` and `'bar` have
+no points where they are (directly) live, since they do not appear in
+the types of any variables.
+
+ * However, this does not mean these lifetimes are irrelevant; as
+   shown below, subtyping constraints introduced by subsequent
+   analyses will eventually require `'foo` and `'bar` to *outlive*
+   `'p`.
 
 #### Liveness-based constraints for lifetimes
 


### PR DESCRIPTION
Attempt to clarify statement about `'foo` and `'bar` being "never live."

In particular, on first reading, it seemed contradictory to say at one point that `'foo` and `'bar` are "never live", and then subsequent analyses do determine that they are live; or at least that they outlive something else that is live (which, in my book, would usually be interpreted to mean "live").