### PR TITLE
Change the un-panic-able loop body to never panic

### DIFF
--- a/0000-nonlexical-lifetimes.md
+++ b/0000-nonlexical-lifetimes.md
@@ -1310,13 +1310,13 @@ uses a (incorrect, but declared as unsafe) API for spawning threads:
 
 ```rust
 let scope = Scope::new();
-let mut foo = 22;
+let mut foo = true;
 
 unsafe {
     // dtor joins the thread
     let _guard = scope.spawn(&mut foo);
     loop {
-        foo += 1;
+        foo = !foo;
     }
     // drop of `_guard` joins the thread
 }


### PR DESCRIPTION
Integers in Rust are defined to panic on overflow, so the supposedly unreachable drop glue was actually going to be reached.

https://github.com/nikomatsakis/nll-rfc/issues/35#issuecomment-326360290